### PR TITLE
Add DefaultLayout to the layout plugin.

### DIFF
--- a/plugins/layout/layout_test.go
+++ b/plugins/layout/layout_test.go
@@ -14,7 +14,7 @@ func Test(t *testing.T) {
 		func(gs *goldsmith.Goldsmith) {
 			gs.
 				Chain(frontmatter.New()).
-				Chain(New())
+				Chain(New().DefaultLayout("page"))
 		},
 	)
 }

--- a/plugins/layout/testdata/reference/defaultindex.html
+++ b/plugins/layout/testdata/reference/defaultindex.html
@@ -1,0 +1,22 @@
+
+<html>
+    <body>
+        
+<h1>Lorem Ipsum</h1>
+
+        
+<p>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed dapibus, ipsum eu
+mattis facilisis, leo nisl congue arcu, laoreet molestie augue leo vel augue.
+Suspendisse quis sodales risus. Phasellus vel nulla et elit mollis facilisis.
+Pellentesque at magna sed orci rutrum eleifend. Nam viverra diam et felis
+pellentesque, id posuere arcu mattis. Nulla venenatis eros odio, sed
+vestibulum lectus hendrerit vitae. Suspendisse consequat id est eu
+sollicitudin. Donec sodales tellus a dolor aliquam ultricies. Vivamus volutpat
+mollis turpis at auctor. Sed vel ex a elit porttitor tempus nec id dolor.
+Curabitur vehicula maximus fermentum. Suspendisse pellentesque et dolor vitae
+efficitur.
+</p>
+
+    </body>
+</html>

--- a/plugins/layout/testdata/source/defaultindex.html
+++ b/plugins/layout/testdata/source/defaultindex.html
@@ -1,0 +1,14 @@
++++
+Title = "Lorem Ipsum"
++++
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed dapibus, ipsum eu
+mattis facilisis, leo nisl congue arcu, laoreet molestie augue leo vel augue.
+Suspendisse quis sodales risus. Phasellus vel nulla et elit mollis facilisis.
+Pellentesque at magna sed orci rutrum eleifend. Nam viverra diam et felis
+pellentesque, id posuere arcu mattis. Nulla venenatis eros odio, sed
+vestibulum lectus hendrerit vitae. Suspendisse consequat id est eu
+sollicitudin. Donec sodales tellus a dolor aliquam ultricies. Vivamus volutpat
+mollis turpis at auctor. Sed vel ex a elit porttitor tempus nec id dolor.
+Curabitur vehicula maximus fermentum. Suspendisse pellentesque et dolor vitae
+efficitur.


### PR DESCRIPTION
The DefaultLayout setting allows you to generate pages without
including a layout in the metadata for every source file.